### PR TITLE
Monitor multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,34 @@ env.password password or logintoken
 env.url https://URL.TO.YOUR.NEXTCLOUD.tld/ocs/v2.php/apps/serverinfo/api/v1/info
 ```
 
+If you run multiple instances of nextcloud on one same system (with NEXTCLOUD_CONFIG_DIR), you should and can name the instances.
+
+```
+[nextcloud_multi.py_firstinstance.nextcloud.tld]
+env.username username
+env.password password or logintoken
+env.url https://FIRSTINSTANCE.NEXTCLOUD.tld/ocs/v2.php/apps/serverinfo/api/v1/info
+
+[nextcloud_multi.py_secondinstance.nextcloud.tld]
+env.username username
+env.password password or logintoken
+env.url https://SECONDINSTANCE.NEXTCLOUD.tld/ocs/v2.php/apps/serverinfo/api/v1/info
+```
+
 ### activating the plugin
 Finally you need to symlink the plugins you would like to activate into the munin plugin directory eg. `/etc/munin/plugins/`. 
 Or if you want to use the multigraph plugin only symlink that one the the munin plugin directory.
+
+Example for a single instance:
+
+`ln -s /path/to/nextcloud/munin/plugins/nextcloud_multi.py /etc/munin/plugins/nextcloud_multi.py`
+
+Example for a multitple instances:
+
+`ln -s /path/to/nextcloud/munin/plugins/nextcloud_multi.py /etc/munin/plugins/nextcloud_multi.py_firstintance.nextcloud.tld`
+
+`ln -s /path/to/nextcloud/munin/plugins/nextcloud_multi.py /etc/munin/plugins/nextcloud_multi.py_second.nextcloud.tld`
+
 
 After this has been done the munin-node needs to be restarted to facilitate the new plugins.
 `systemctl restart munin-node`

--- a/nextcloud_apps.py
+++ b/nextcloud_apps.py
@@ -23,7 +23,7 @@ class NextcloudApps:
         title = title.split("nextcloud_apps.py_",1)[1]
         if title:
             title = ' on ' + title
-        else
+        else:
             title = ''
 
         self.config = [
@@ -32,7 +32,7 @@ class NextcloudApps:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel updates available',
-            'graph_info graph showing the number of available app updates',
+            'graph_info graph showing the number of available app updates' + title,
             'graph_category nextcloud',
             'num_updates_available.label available app updates',
             'num_updates_available.info number of available app updates',

--- a/nextcloud_apps.py
+++ b/nextcloud_apps.py
@@ -19,9 +19,16 @@ import os
 
 class NextcloudApps:
     def __init__(self):
+        title = os.path.basename(__file__)
+        title = title.split("nextcloud_apps.py_",1)[1]
+        if title:
+            title = ' on ' + title
+        else
+            title = ''
+
         self.config = [
             # available_updates
-            'graph_title Nextcloud available App updates',
+            'graph_title Nextcloud available App updates' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel updates available',

--- a/nextcloud_dbsize.py
+++ b/nextcloud_dbsize.py
@@ -19,9 +19,16 @@ import os
 
 class NextcloudDB:
     def __init__(self):
+        title = os.path.basename(__file__)
+        title = title.split("nextcloud_apps.py_",1)[1]
+        if title:
+            title = ' on ' + title
+        else
+            title = ''
+
         self.config = [
             # dbsize
-            'graph_title Nextcloud Database Size',
+            'graph_title Nextcloud Database Size' + title,
             'graph_args --base 1024 -l 0',
             'graph_vlabel size in byte',
             'graph_info graph showing the database size in byte',

--- a/nextcloud_dbsize.py
+++ b/nextcloud_dbsize.py
@@ -23,7 +23,7 @@ class NextcloudDB:
         title = title.split("nextcloud_apps.py_",1)[1]
         if title:
             title = ' on ' + title
-        else
+        else:
             title = ''
 
         self.config = [
@@ -31,7 +31,7 @@ class NextcloudDB:
             'graph_title Nextcloud Database Size' + title,
             'graph_args --base 1024 -l 0',
             'graph_vlabel size in byte',
-            'graph_info graph showing the database size in byte',
+            'graph_info graph showing the database size in byte' + title,
             'graph_category nextcloud',
             'db_size.label database size in byte',
             'db_size.info users connected in the last 5 minutes',

--- a/nextcloud_files.py
+++ b/nextcloud_files.py
@@ -19,9 +19,16 @@ import os
 
 class NextcloudStorage:
     def __init__(self):
+        title = os.path.basename(__file__)
+        title = title.split("nextcloud_apps.py_",1)[1]
+        if title:
+            title = ' on ' + title
+        else
+            title = ''
+
         self.config = [
             # filecount
-            'graph_title Nextcloud Files',
+            'graph_title Nextcloud Files' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number of files',

--- a/nextcloud_files.py
+++ b/nextcloud_files.py
@@ -23,7 +23,7 @@ class NextcloudStorage:
         title = title.split("nextcloud_apps.py_",1)[1]
         if title:
             title = ' on ' + title
-        else
+        else:
             title = ''
 
         self.config = [
@@ -32,7 +32,7 @@ class NextcloudStorage:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number of files',
-            'graph_info graph showing the number of files',
+            'graph_info graph showing the number of files' + title,,
             'graph_category nextcloud',
             'num_files.label number of files',
             'num_files.info current number of files in the repository',

--- a/nextcloud_multi.py
+++ b/nextcloud_multi.py
@@ -27,7 +27,7 @@ class NextcloudMultiGraph:
         title = title.split("nextcloud_apps.py_",1)[1]
         if title:
             title = ' on ' + title
-        else
+        else:
             title = ''
 
         self.config = [
@@ -37,7 +37,7 @@ class NextcloudMultiGraph:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel connected users',
-            'graph_info graph showing the number of connected user',
+            'graph_info graph showing the number of connected user' + title,
             'graph_category nextcloud',
             'last5minutes.label last 5 minutes',
             'last5minutes.info users connected in the last 5 minutes',
@@ -58,7 +58,7 @@ class NextcloudMultiGraph:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number of shares',
-            'graph_info graph showing the number of shares',
+            'graph_info graph showing the number of shares' + title,
             'graph_category nextcloud',
             'num_shares.label total number of shares',
             'num_shares.info current over all total of shares',
@@ -93,7 +93,7 @@ class NextcloudMultiGraph:
             'graph_title Nextcloud Database Size' + title,
             'graph_args --base 1024 -l 0',
             'graph_vlabel size in byte',
-            'graph_info graph showing the database size in byte',
+            'graph_info graph showing the database size in byte' + title,
             'graph_category nextcloud',
             'db_size.label database size in byte',
             'db_size.info users connected in the last 5 minutes',
@@ -106,7 +106,7 @@ class NextcloudMultiGraph:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel updates available',
-            'graph_info graph showing the number of available app updates',
+            'graph_info graph showing the number of available app updates' + title,
             'graph_category nextcloud',
             'num_updates_available.label available app updates',
             'num_updates_available.info number of available app updates',
@@ -119,7 +119,7 @@ class NextcloudMultiGraph:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number',
-            'graph_info graph showing the number of storages',
+            'graph_info graph showing the number of storages' + title,
             'graph_category nextcloud',
             'num_storages.label total number of storages',
             'num_storages.info current over all total of storages',
@@ -140,7 +140,7 @@ class NextcloudMultiGraph:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number of files',
-            'graph_info graph showing the number of files',
+            'graph_info graph showing the number of files' + title,
             'graph_category nextcloud',
             'num_files.label number of files',
             'num_files.info current number of files in the repository',

--- a/nextcloud_multi.py
+++ b/nextcloud_multi.py
@@ -23,10 +23,17 @@ import os
 
 class NextcloudMultiGraph:
     def __init__(self):
+        title = os.path.basename(__file__)
+        title = title.split("nextcloud_apps.py_",1)[1]
+        if title:
+            title = ' on ' + title
+        else
+            title = ''
+
         self.config = [
             # users
             'multigraph nextcloud_users',
-            'graph_title Nextcloud User Activity',
+            'graph_title Nextcloud User Activity' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel connected users',
@@ -47,7 +54,7 @@ class NextcloudMultiGraph:
 
             # shares
             'multigraph nextcloud_shares',
-            'graph_title Nextcloud Shares',
+            'graph_title Nextcloud Shares' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number of shares',
@@ -83,7 +90,7 @@ class NextcloudMultiGraph:
 
             # dbsize
             'multigraph nextcloud_dbsize',
-            'graph_title Nextcloud Database Size',
+            'graph_title Nextcloud Database Size' + title,
             'graph_args --base 1024 -l 0',
             'graph_vlabel size in byte',
             'graph_info graph showing the database size in byte',
@@ -95,7 +102,7 @@ class NextcloudMultiGraph:
 
             # available_updates
             'multigraph nextcloud_available_updates',
-            'graph_title Nextcloud available App updates',
+            'graph_title Nextcloud available App updates' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel updates available',
@@ -108,7 +115,7 @@ class NextcloudMultiGraph:
 
             # storages
             'multigraph nextcloud_storages',
-            'graph_title Nextcloud Storages',
+            'graph_title Nextcloud Storages' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number',
@@ -129,7 +136,7 @@ class NextcloudMultiGraph:
 
             # filecount
             'multigraph nextcloud_filecount',
-            'graph_title Nextcloud Files',
+            'graph_title Nextcloud Files' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number of files',

--- a/nextcloud_shares.py
+++ b/nextcloud_shares.py
@@ -19,9 +19,16 @@ import os
 
 class NextcloudShares:
     def __init__(self):
+        title = os.path.basename(__file__)
+        title = title.split("nextcloud_apps.py_",1)[1]
+        if title:
+            title = ' on ' + title
+        else
+            title = ''
+
         self.config = [
             # shares
-            'graph_title Nextcloud Shares',
+            'graph_title Nextcloud Shares' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number of shares',

--- a/nextcloud_shares.py
+++ b/nextcloud_shares.py
@@ -23,7 +23,7 @@ class NextcloudShares:
         title = title.split("nextcloud_apps.py_",1)[1]
         if title:
             title = ' on ' + title
-        else
+        else:
             title = ''
 
         self.config = [
@@ -32,7 +32,7 @@ class NextcloudShares:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number of shares',
-            'graph_info graph showing the number of shares',
+            'graph_info graph showing the number of shares' + title,
             'graph_category nextcloud',
             'num_shares.label total number of shares',
             'num_shares.info current over all total of shares',

--- a/nextcloud_storage.py
+++ b/nextcloud_storage.py
@@ -23,7 +23,7 @@ class NextcloudStorage:
         title = title.split("nextcloud_apps.py_",1)[1]
         if title:
             title = ' on ' + title
-        else
+        else:
             title = ''
 
         self.config = [
@@ -32,7 +32,7 @@ class NextcloudStorage:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number',
-            'graph_info graph showing the number of storages',
+            'graph_info graph showing the number of storages' + title,
             'graph_category nextcloud',
             'num_storages.label total number of storages',
             'num_storages.info current over all total of storages',

--- a/nextcloud_storage.py
+++ b/nextcloud_storage.py
@@ -19,9 +19,16 @@ import os
 
 class NextcloudStorage:
     def __init__(self):
+        title = os.path.basename(__file__)
+        title = title.split("nextcloud_apps.py_",1)[1]
+        if title:
+            title = ' on ' + title
+        else
+            title = ''
+
         self.config = [
             # storages
-            'graph_title Nextcloud Storages',
+            'graph_title Nextcloud Storages' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel number',

--- a/nextcloud_users.py
+++ b/nextcloud_users.py
@@ -23,7 +23,7 @@ class NextcloudUsers:
         title = title.split("nextcloud_apps.py_",1)[1]
         if title:
             title = ' on ' + title
-        else
+        else:
             title = ''
 
         self.config = [
@@ -32,7 +32,7 @@ class NextcloudUsers:
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel connected users',
-            'graph_info graph showing the number of connected user',
+            'graph_info graph showing the number of connected user' + title,
             'graph_category nextcloud',
             'last5minutes.label last 5 minutes',
             'last5minutes.info users connected in the last 5 minutes',

--- a/nextcloud_users.py
+++ b/nextcloud_users.py
@@ -19,9 +19,16 @@ import os
 
 class NextcloudUsers:
     def __init__(self):
+        title = os.path.basename(__file__)
+        title = title.split("nextcloud_apps.py_",1)[1]
+        if title:
+            title = ' on ' + title
+        else
+            title = ''
+
         self.config = [
             # users
-            'graph_title Nextcloud User Activity',
+            'graph_title Nextcloud User Activity' + title,
             'graph_args --base 1000 -l 0',
             'graph_printf %.0lf',
             'graph_vlabel connected users',


### PR DESCRIPTION
Make nextcloud munin plugins capable of monitoring multiple nextcloud instances on one system, configurable by appending instance name to plugin link.

